### PR TITLE
Only test alpha channel values

### DIFF
--- a/Tests/test_image_convert.py
+++ b/Tests/test_image_convert.py
@@ -222,18 +222,18 @@ def test_p_la():
     assert_image_similar(alpha, comparable, 5)
 
 
-def test_p_pa():
+def test_p2pa_alpha():
     with Image.open("Tests/images/tiny.png") as im:
         assert im.mode == "P"
 
         im_pa = im.convert("PA")
-        assert im_pa.mode == "PA"
+    assert im_pa.mode == "PA"
 
-        assert (
-            im_pa.tobytes() == b"\x00\x00\x00\x00\x08\xff\x04\xff\x00\x00\x00\x00"
-            b"\x06\xff\x07\xff\x00\x00\x00\x00\x02\xff\x03\xff\x00"
-            b"\x00\x00\x00\x01\xff\x05\xff"
-        )
+    im_a = im_pa.getchannel("A")
+    for x in range(4):
+        alpha = 255 if x > 1 else 0
+        for y in range(4):
+            assert im_a.getpixel((x, y)) == alpha
 
 
 def test_matrix_illegal_conversion():


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/6337

I've changed the test to only check the alpha channel values. This seems more human readable.